### PR TITLE
AWS Provider 5.0 upgrade

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "s3-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
Bumps version constraint to ~> 5.0.
Related to https://github.com/ministryofjustice/modernisation-platform/issues/4173