### PR TITLE
Address code analysis alerts

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,8 +8,13 @@ on:
       - '**.md'
       - '.github/workflows/documentation.yml'
 
+permissions: {}
+
 jobs:
   docs:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you're looking to raise an issue with this module, please create a new issue 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | v7.0.0 |
+| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | 8688bc15a08fbf5a4f4eef9b7433c5a417df8df1 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "s3-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=8688bc15a08fbf5a4f4eef9b7433c5a417df8df1"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication
@@ -81,6 +81,9 @@ data "aws_iam_policy_document" "vmimport-trust-policy" {
 
 #tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_policy" "vmimport-policy" {
+#checkov:skip=CKV_AWS_289: "Wildcard used as this is a consumable module"
+#checkov:skip=CKV_AWS_290: "Wildcard used as this is a consumable module"
+#checkov:skip=CKV_AWS_355: "ec2:Describe* achieves same goal as allowing all describe actions"
   name   = "vmimport-policy-${var.application_name}"
   policy = <<EOF
 {


### PR DESCRIPTION
* Added Checkov skips for alerts that aren't applicable here
* Pinned S3 bucket module to a commit hash, rather than a tag
* Added `permissions {}` statements to GitHub docs action