### PR TITLE
fix: declare aws.bucket-replication as configuration alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ module "vm-import" {
 
   source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-vm-import"
 
+  providers = {
+    aws.bucket-replication = aws
+  }
+
   bucket_prefix    = local.application_data.accounts[local.environment].bucket_prefix
   tags             = local.tags
   application_name = local.application_name
@@ -71,50 +75,52 @@ module "vm-import" {
 If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
+| Name                                                                     | Version |
+| ------------------------------------------------------------------------ | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.0  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 6.0  |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| Name                                             | Version |
+| ------------------------------------------------ | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 6.0  |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | 9facf9fc8f8b8e3f93ffbda822028534b9a75399 |
+| Name                                                           | Source                                                                  | Version                                  |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------- |
+| <a name="module_s3-bucket"></a> [s3-bucket](#module_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | 9facf9fc8f8b8e3f93ffbda822028534b9a75399 |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_iam_policy.vmimport-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.vmimport_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_policy_document.vmimport-trust-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| Name                                                                                                                                                                | Type        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_iam_policy.vmimport-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                                            | resource    |
+| [aws_iam_role.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                                       | resource    |
+| [aws_iam_role_policy_attachment.vmimport_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource    |
+| [aws_iam_policy_document.vmimport-trust-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                 | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_account_number"></a> [account\_number](#input\_account\_number) | Account number of current environment | `string` | n/a | yes |
-| <a name="input_application_name"></a> [application\_name](#input\_application\_name) | Name of application | `string` | n/a | yes |
-| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for s3 bucket | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created | `string` | `"eu-west-2"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Common tags to be used by all resources | `map(string)` | n/a | yes |
+| Name                                                                              | Description                                    | Type          | Default       | Required |
+| --------------------------------------------------------------------------------- | ---------------------------------------------- | ------------- | ------------- | :------: |
+| <a name="input_account_number"></a> [account_number](#input_account_number)       | Account number of current environment          | `string`      | n/a           |   yes    |
+| <a name="input_application_name"></a> [application_name](#input_application_name) | Name of application                            | `string`      | n/a           |   yes    |
+| <a name="input_bucket_prefix"></a> [bucket_prefix](#input_bucket_prefix)          | Prefix for s3 bucket                           | `string`      | n/a           |   yes    |
+| <a name="input_region"></a> [region](#input_region)                               | The AWS region where resources will be created | `string`      | `"eu-west-2"` |    no    |
+| <a name="input_tags"></a> [tags](#input_tags)                                     | Common tags to be used by all resources        | `map(string)` | n/a           |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_policy"></a> [policy](#output\_policy) | IAM policy name output |
-| <a name="output_role"></a> [role](#output\_role) | IAM role name output |
+| Name                                                  | Description            |
+| ----------------------------------------------------- | ---------------------- |
+| <a name="output_policy"></a> [policy](#output_policy) | IAM policy name output |
+| <a name="output_role"></a> [role](#output_role)       | IAM role name output   |
+
 <!-- END_TF_DOCS -->
 
 [Standards Link]: https://github-community.service.justice.gov.uk/repository-standards/modernisation-platform-terraform-aws-vm-import "Repo standards badge."

--- a/README.md
+++ b/README.md
@@ -75,52 +75,50 @@ module "vm-import" {
 If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version |
-| ------------------------------------------------------------------------ | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.0  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 6.0  |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
-| Name                                             | Version |
-| ------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 6.0  |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 
-| Name                                                           | Source                                                                  | Version                                  |
-| -------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------- |
-| <a name="module_s3-bucket"></a> [s3-bucket](#module_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | 9facf9fc8f8b8e3f93ffbda822028534b9a75399 |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | 9facf9fc8f8b8e3f93ffbda822028534b9a75399 |
 
 ## Resources
 
-| Name                                                                                                                                                                | Type        |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_iam_policy.vmimport-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                                            | resource    |
-| [aws_iam_role.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                                       | resource    |
-| [aws_iam_role_policy_attachment.vmimport_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource    |
-| [aws_iam_policy_document.vmimport-trust-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                 | data source |
+| Name | Type |
+|------|------|
+| [aws_iam_policy.vmimport-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.vmimport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.vmimport_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.vmimport-trust-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
-| Name                                                                              | Description                                    | Type          | Default       | Required |
-| --------------------------------------------------------------------------------- | ---------------------------------------------- | ------------- | ------------- | :------: |
-| <a name="input_account_number"></a> [account_number](#input_account_number)       | Account number of current environment          | `string`      | n/a           |   yes    |
-| <a name="input_application_name"></a> [application_name](#input_application_name) | Name of application                            | `string`      | n/a           |   yes    |
-| <a name="input_bucket_prefix"></a> [bucket_prefix](#input_bucket_prefix)          | Prefix for s3 bucket                           | `string`      | n/a           |   yes    |
-| <a name="input_region"></a> [region](#input_region)                               | The AWS region where resources will be created | `string`      | `"eu-west-2"` |    no    |
-| <a name="input_tags"></a> [tags](#input_tags)                                     | Common tags to be used by all resources        | `map(string)` | n/a           |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_number"></a> [account\_number](#input\_account\_number) | Account number of current environment | `string` | n/a | yes |
+| <a name="input_application_name"></a> [application\_name](#input\_application\_name) | Name of application | `string` | n/a | yes |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for s3 bucket | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created | `string` | `"eu-west-2"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tags to be used by all resources | `map(string)` | n/a | yes |
 
 ## Outputs
 
-| Name                                                  | Description            |
-| ----------------------------------------------------- | ---------------------- |
-| <a name="output_policy"></a> [policy](#output_policy) | IAM policy name output |
-| <a name="output_role"></a> [role](#output_role)       | IAM role name output   |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_policy"></a> [policy](#output\_policy) | IAM policy name output |
+| <a name="output_role"></a> [role](#output\_role) | IAM role name output |
 <!-- END_TF_DOCS -->
 
 [Standards Link]: https://github-community.service.justice.gov.uk/repository-standards/modernisation-platform-terraform-aws-vm-import "Repo standards badge."

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  alias  = "bucket-replication"
-  region = var.region
-  assume_role {
-    role_arn = "arn:aws:iam::${var.account_number}:role/MemberInfrastructureAccess"
-  }
-}

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -2,6 +2,10 @@ module "vm-import" {
 
   source = "../../"
 
+  providers = {
+    aws.bucket-replication = aws
+  }
+
   bucket_prefix    = local.application_data.accounts["test"].bucket_prefix
   tags             = local.tags
   application_name = local.application_name

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
-      source  = "hashicorp/aws"
+      version               = "~> 6.0"
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.bucket-replication]
     }
   }
   required_version = "~> 1.0"


### PR DESCRIPTION
## What

- Add `configuration_aliases = [aws.bucket-replication]` to `required_providers` in `versions.tf`
- Remove the hardcoded internal `provider "aws" { alias = "bucket-replication" }` from `providers.tf`

## Why

The module defined `aws.bucket-replication` internally with a hardcoded `MemberInfrastructureAccess` role assumption. This caused plan failures in pipelines where the runner role (e.g. `github-actions-plan`) does not have permission to assume that role:

```
Error: Cannot assume IAM Role
  with module.vm-import.provider["registry.terraform.io/hashicorp/aws"].bucket-replication
IAM Role (...MemberInfrastructureAccess) cannot be assumed.
```

By declaring `configuration_aliases = [aws.bucket-replication]`, the provider is now supplied by the caller, giving them full control over the credentials used — consistent with how other MP modules handle aliased providers.

Callers where replication is disabled can simply pass the default provider:

```hcl
providers = {
  aws.bucket-replication = aws
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)