### PR TITLE
Adds dependabot cooldown feature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       action-dependencies:
         patterns:
@@ -13,10 +15,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gomod"
     directory: "/test"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       gomod-dependencies:
         patterns:


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/12036

## How does this PR fix the problem?

Adds Dependabot cooldown configuration so newly released dependency versions must now wait 7 days by default before 
Dependabot raises a version-update PR 